### PR TITLE
Fix file link creation

### DIFF
--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -1039,11 +1039,11 @@ class ATPOutputView extends View
 
     str = filename
     name_tokens = filename
-    filename = filename.replace /:[0-9]+:[0-9]/ig, ''
+    filename = filename.replace /:[0-9]+:[0-9]+/ig, ''
     name_tokens = @util.replaceAll filename, '', name_tokens
     name_tokens = name_tokens.split ':'
-    fileline = name_tokens[0]
-    filecolumn = name_tokens[1]
+    fileline = name_tokens[1]-1
+    filecolumn = name_tokens[2]-1
 
     filename = @util.replaceAll '/', '\\', filename
     filename = @util.replaceAll parent, '', filename


### PR DESCRIPTION
Atom needs fileline and column in 0-based.
Whereas most command lines print in 1-based form.

Also file column can be more than 1 letter. So fixing that regex.